### PR TITLE
Update README.md

### DIFF
--- a/charts/free5gc/README.md
+++ b/charts/free5gc/README.md
@@ -96,10 +96,12 @@ helm -n <namespace> uninstall <release-name>
 If you want to enable the ULCL feature, you can use the [ulcl-enabled-values.yaml](./ulcl-enabled-values.yaml) to override the default chart values.
 
 ### Networks configuration
+
 In this section, we'll suppose that you have only one interface on each Kubernetes node and its name is `toto`. Then you have to set these parameters to `toto`:
  - `global.n2network.masterIf`
  - `global.n3network.masterIf`
  - `global.n4network.masterIf`
+ - `global.n6network.masterIf`
  - `global.n9network.masterIf`
 
 In addition, please make sure `global.n6network.subnetIP`, `global.n6network.gatewayIP` and `free5gc-upf.upf.n6if.IpAddress` parameters will match the IP address of the `toto` interface in order to make the UPF able to reach the Data Network via its N6 interface.

--- a/charts/free5gc/README.md
+++ b/charts/free5gc/README.md
@@ -100,7 +100,7 @@ In this section, we'll suppose that you have only one interface on each Kubernet
  - `global.n2network.masterIf`
  - `global.n3network.masterIf`
  - `global.n4network.masterIf`
- - `global.n6network.masterIf`
+ - `global.n9network.masterIf`
 
 In addition, please make sure `global.n6network.subnetIP`, `global.n6network.gatewayIP` and `upf.n6if.IpAddress` parameters will match the IP address of the `toto` interface in order to make the UPF able to reach the Data Network via its N6 interface.
 
@@ -180,7 +180,7 @@ These parameters if `global.userPlaneArchitecture` is set to `ulcl`.
 | --- | --- | --- |
 These parameters if `global.userPlaneArchitecture` is set to `ulcl`.
 | `global.n9network.name` | N9 network name. | `n9network` |
-| `global.n9network.masterIf` | N9 network MACVLAN master interface. The IP address of this interface must be in the N9 network subnet IP rang. | `eth1` |
+| `global.n9network.masterIf` | N9 network MACVLAN master interface. The IP address of this interface must be in the N9 network subnet IP rang. | `eth0` |
 | `global.n9network.subnetIP` | N9 network subnet IP address (The IP address of the Data Network. | `10.100.50.224` |
 | `global.n9network.cidr` | N9 network cidr. | `29` |
 | `global.n9network.gatewayIP` | N9 network gateway IP address (The IP address to go to the Data Network). | `10.100.50.230` |


### PR DESCRIPTION
I believe the N9 network should be on eth0, only the N6 network should be on eth1. I might be wrong. In any case, they are some inconsistencies between the README and the values.yaml file associated to the free5gc chart.