### PR TITLE
Fix TLS Errors on NRF logs when deploying free5gc with https scheme

### DIFF
--- a/charts/free5gc/charts/free5gc-amf/templates/amf-deployment.yaml
+++ b/charts/free5gc/charts/free5gc-amf/templates/amf-deployment.yaml
@@ -58,7 +58,7 @@ spec:
         env:
         - name: DEPENDENCIES
           value: {{ $.Values.global.sbi.scheme }}://{{ $.Values.global.nrf.service.name }}:{{ $.Values.global.nrf.service.port }}
-        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']   
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']   
       
       containers:
       - name: {{ .name }}

--- a/charts/free5gc/charts/free5gc-ausf/templates/ausf-deployment.yaml
+++ b/charts/free5gc/charts/free5gc-ausf/templates/ausf-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         env:
         - name: DEPENDENCIES
           value: {{ $.Values.global.sbi.scheme }}://{{ $.Values.global.nrf.service.name }}:{{ $.Values.global.nrf.service.port }}
-        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
       
       containers:
       - name: {{ .name }}

--- a/charts/free5gc/charts/free5gc-nssf/templates/nssf-deployment.yaml
+++ b/charts/free5gc/charts/free5gc-nssf/templates/nssf-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         env:
         - name: DEPENDENCIES
           value: {{ $.Values.global.sbi.scheme }}://{{ $.Values.global.nrf.service.name }}:{{ $.Values.global.nrf.service.port }}
-        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
 
       containers:
       - name: {{ .name }}

--- a/charts/free5gc/charts/free5gc-pcf/templates/pcf-deployment.yaml
+++ b/charts/free5gc/charts/free5gc-pcf/templates/pcf-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         env:
         - name: DEPENDENCIES
           value: {{ $.Values.global.sbi.scheme }}://{{ $.Values.global.nrf.service.name }}:{{ $.Values.global.nrf.service.port }}
-        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
 
 
       containers:

--- a/charts/free5gc/charts/free5gc-smf/templates/smf-deployment.yaml
+++ b/charts/free5gc/charts/free5gc-smf/templates/smf-deployment.yaml
@@ -56,7 +56,7 @@ spec:
         env:
         - name: DEPENDENCIES
           value: {{ $.Values.global.sbi.scheme }}://{{ $.Values.global.nrf.service.name }}:{{ $.Values.global.nrf.service.port }}
-        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
 
 
       containers:

--- a/charts/free5gc/charts/free5gc-udm/templates/udm-deployment.yaml
+++ b/charts/free5gc/charts/free5gc-udm/templates/udm-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         env:
         - name: DEPENDENCIES
           value: {{ $.Values.global.sbi.scheme }}://{{ $.Values.global.nrf.service.name }}:{{ $.Values.global.nrf.service.port }}
-        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
 
       containers:
       - name: {{ .name }}

--- a/charts/free5gc/charts/free5gc-udr/templates/udr-deployment.yaml
+++ b/charts/free5gc/charts/free5gc-udr/templates/udr-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         env:
         - name: DEPENDENCIES
           value: {{ $.Values.global.sbi.scheme }}://{{ $.Values.global.nrf.service.name }}:{{ $.Values.global.nrf.service.port }}
-        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
+        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --insecure --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']
 
       containers:
       - name: {{ .name }}


### PR DESCRIPTION
In NRF log several errors like:
`2021/11/22 10:36:14 http:  TLS handshake error from 172.10.0.31:56962: local error: tls: bad record MAC`

This error is caused by the initContainers of other NFs waiting for NRF readiness on its https endpoint
```
      initContainers:
      - name: wait-nrf
        {{- with $.Values.initcontainers.curl }}
        image: {{ .registry }}/{{ .image }}:{{ .tag }}
        {{- end }}
        env:
        - name: DEPENDENCIES
          value: {{ $.Values.global.sbi.scheme }}://{{ $.Values.global.nrf.service.name }}:{{ $.Values.global.nrf.service.port }}
        command: ['sh', '-c', 'set -x; for dependency in $DEPENDENCIES; do while [ $(curl --connect-timeout 1 -s -o /dev/null -w "%{http_code}" $dependency) -ne 200 ]; do echo waiting for dependencies; sleep 1; done; done;']   
      
```
The NFs pod stay in an infinite Init state waiting for initContainers terminating... 