### PR TITLE
Update Setup-free5gc-and-test-with-UERANSIM.md

### DIFF
--- a/docs/demo/Setup-free5gc-and-test-with-UERANSIM.md
+++ b/docs/demo/Setup-free5gc-and-test-with-UERANSIM.md
@@ -46,6 +46,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: example-local-pv9
+  namespace: <namespace>
   labels:
     project: free5gc
 spec:


### PR DESCRIPTION
When creating the persistent volume user should specify the "namespace" in the metadata. Otherwise, the volume will not persist in the desired namespace. Had to learn the hard way because it was missing :D