### PR TITLE
Update smf-deployment.yaml

### DIFF
--- a/charts/free5gc/charts/free5gc-smf/templates/smf-deployment.yaml
+++ b/charts/free5gc/charts/free5gc-smf/templates/smf-deployment.yaml
@@ -67,8 +67,6 @@ spec:
         securityContext:
             {{- toYaml .securityContext | nindent 12 }}
         ports:
-        - containerPort: {{ .service.port }}
-        ports:
         - name: nsmf
           containerPort: {{ .service.port }}
         {{- if $.Values.isPfcpNeeded }}


### PR DESCRIPTION
ports key duplicated on line 69 causing flux helm install to fail with:
```
Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
           	  	     	     	  line 63: mapping key "ports" already defined at line 61```