### PR TITLE
fix HPA and update apiVersion

### DIFF
--- a/charts/free5gc/charts/free5gc-amf/templates/amf-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-amf/templates/amf-hpa.yaml
@@ -12,17 +12,17 @@
 #
 {{- with .Values.amf }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-amf.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-amf.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-amf.labels" . | nindent 4 }}
+    {{- include "free5gc-amf.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-amf.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-amf.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -30,13 +30,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-ausf/templates/ausf-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-ausf/templates/ausf-hpa.yaml
@@ -12,17 +12,17 @@
 #
 {{- with .Values.ausf }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-ausf.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-ausf.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-ausf.labels" . | nindent 4 }}
+    {{- include "free5gc-ausf.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-ausf.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-ausf.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -30,13 +30,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-n3iwf/templates/n3iwf-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-n3iwf/templates/n3iwf-hpa.yaml
@@ -12,17 +12,17 @@
 #
 {{- with .Values.n3iwf }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-n3iwf.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-n3iwf.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-n3iwf.labels" . | nindent 4 }}
+    {{- include "free5gc-n3iwf.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-n3iwf.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-n3iwf.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -30,13 +30,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-nrf/templates/nrf-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-nrf/templates/nrf-hpa.yaml
@@ -12,17 +12,17 @@
 #
 {{- with .Values.nrf }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-nrf.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-nrf.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-nrf.labels" . | nindent 4 }}
+    {{- include "free5gc-nrf.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-nrf.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-nrf.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -30,13 +30,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-nssf/templates/nssf-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-nssf/templates/nssf-hpa.yaml
@@ -12,17 +12,17 @@
 #
 {{- with .Values.nssf }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-nssf.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-nssf.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-nssf.labels" . | nindent 4 }}
+    {{- include "free5gc-nssf.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-nssf.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-nssf.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -30,13 +30,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-pcf/templates/pcf-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-pcf/templates/pcf-hpa.yaml
@@ -12,17 +12,17 @@
 #
 {{- with .Values.pcf }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-pcf.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-pcf.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-pcf.labels" . | nindent 4 }}
+    {{- include "free5gc-pcf.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-pcf.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-pcf.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -30,13 +30,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-smf/templates/smf-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-smf/templates/smf-hpa.yaml
@@ -12,17 +12,17 @@
 #
 {{- with .Values.smf }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-smf.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-smf.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-smf.labels" . | nindent 4 }}
+    {{- include "free5gc-smf.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-smf.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-smf.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -30,13 +30,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-udm/templates/udm-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-udm/templates/udm-hpa.yaml
@@ -12,17 +12,17 @@
 #
 {{- with .Values.udm }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-udm.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-udm.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-udm.labels" . | nindent 4 }}
+    {{- include "free5gc-udm.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-udm.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-udm.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -30,13 +30,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-udr/templates/udr-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-udr/templates/udr-hpa.yaml
@@ -12,17 +12,17 @@
 #
 {{- with .Values.udr }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-udr.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-udr.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-udr.labels" . | nindent 4 }}
+    {{- include "free5gc-udr.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-udr.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-udr.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -30,13 +30,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-upf/templates/upf/upf-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-upf/templates/upf/upf-hpa.yaml
@@ -13,17 +13,17 @@
 {{- if eq .Values.global.userPlaneArchitecture "single" }}
 {{- with .Values.upf }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-upf.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-upf.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-upf.labels" . | nindent 4 }}
+    {{- include "free5gc-upf.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-upf.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-upf.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -31,13 +31,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-upf/templates/upf1/upf1-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-upf/templates/upf1/upf1-hpa.yaml
@@ -13,17 +13,17 @@
 {{- if eq .Values.global.userPlaneArchitecture "ulcl" }}
 {{- with .Values.upf1 }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-upf.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-upf.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-upf.labels" . | nindent 4 }}
+    {{- include "free5gc-upf.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-upf.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-upf.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -31,13 +31,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-upf/templates/upf2/upf2-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-upf/templates/upf2/upf2-hpa.yaml
@@ -13,17 +13,17 @@
 {{- if eq .Values.global.userPlaneArchitecture "ulcl" }}
 {{- with .Values.upf2 }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-upf.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-upf.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-upf.labels" . | nindent 4 }}
+    {{- include "free5gc-upf.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-upf.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-upf.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -31,13 +31,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-upf/templates/upfb/upfb-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-upf/templates/upfb/upfb-hpa.yaml
@@ -13,17 +13,17 @@
 {{- if eq .Values.global.userPlaneArchitecture "ulcl" }}
 {{- with .Values.upfb }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-upf.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-upf.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-upf.labels" . | nindent 4 }}
+    {{- include "free5gc-upf.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-upf.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-upf.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -31,13 +31,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/free5gc/charts/free5gc-webui/templates/webui-hpa.yaml
+++ b/charts/free5gc/charts/free5gc-webui/templates/webui-hpa.yaml
@@ -12,17 +12,17 @@
 #
 {{- with .Values.webui }}
 {{- if .autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "free5gc-webui.fullname" . }}-{{ .name }}-hpa
+  name: {{ include "free5gc-webui.fullname" $ }}-{{ .name }}-hpa
   labels:
-    {{- include "free5gc-webui.labels" . | nindent 4 }}
+    {{- include "free5gc-webui.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "free5gc-webui.fullname" . }}-{{ .name }}
+    name: {{ include "free5gc-webui.fullname" $ }}-{{ .name }}
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
@@ -30,13 +30,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Fix issue #66 and update API version to `autoscaling/v2`


Note: if we leave the `{{ name }}` in `name: {{ include "free5gc-amf.fullname" $ }}-{{ .name }}-hpa` the name of the HPA will be something like `free5gc-free5gc-amf-amf-hpa` with `amf` repeated twice. Wouldn't it be better to remove it?
Almost the same thing is for `name: {{ include "free5gc-amf.fullname" $ }}-{{ .name }}`.

What do you think?

Thanks to @raoufkh for the advice on the solution!