### PR TITLE
fix: setting for enable/disable ueransim tests

### DIFF
--- a/charts/ueransim/Chart.yaml
+++ b/charts/ueransim/Chart.yaml
@@ -13,7 +13,7 @@
 apiVersion: v2
 name: ueransim
 description: A Helm chart to deploy UERANSIM
-version: 2.0.15
+version: 2.0.16
 appVersion: v3.2.6
 icon: https://raw.githubusercontent.com/aligungr/UERANSIM/master/.github/logo.png
 maintainers:

--- a/charts/ueransim/templates/tests/connectivity-test.yaml
+++ b/charts/ueransim/templates/tests/connectivity-test.yaml
@@ -10,7 +10,7 @@
 # Author: Abderaouf KHICHANE, Ilhem FAJJARI, Ayoub BOUSSELMI, Michal CHABIERA
 # Software description: An open-source project providing Helm charts to deploy 5G components (Core + RAN) on top of Kubernetes
 #
-{{- if .Values.ue.enabled }}
+{{- if and .Values.ue.enabled .Values.ue.test.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/ueransim/values.yaml
+++ b/charts/ueransim/values.yaml
@@ -174,6 +174,7 @@ ue:
       downlink: 'full'
 
   test:
+    enabled: true
     connectivity:
       name: ue-connectivity-test
       image: bitnami/kubectl:1.22.0


### PR DESCRIPTION
Hello!

Thanks for your charts - they're great! But I found one problem - sometimes we need to install one chart for different namespaces, in this case - on the second install, helm cannot create the ClusterRole (because the role is already created on the first install)

run first installation:
```
$ helm upgrade --install ueransim towards5gs/ueransim --namespace test1 --version 2.0.15
Release "ueransim" does not exist. Installing it now.
NAME: ueransim
LAST DEPLOYED: Sun Mar 12 23:28:21 2023
NAMESPACE: test1
STATUS: deployed
REVISION: 1
NOTES:
...
```

run second installation:
```
$ helm upgrade --install ueransim towards5gs/ueransim --namespace test2 --version 2.0.15
Release "ueransim" does not exist. Installing it now.
Error: rendered manifests contain a resource that already exists. Unable to continue with install: ClusterRole "ueransim-test-connection" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "test2": current value is "test1"
```

for fix that, i added setting `ue.test.enabled` (default is true) - we can disable tests for next installations. This settings just minor change, not breaks compatibility
