### PR TITLE
Fix deployment failure after upgrade to Free5gc 3.3.0

### DIFF
--- a/charts/free5gc/charts/free5gc-amf/templates/amf-configmap.yaml
+++ b/charts/free5gc/charts/free5gc-amf/templates/amf-configmap.yaml
@@ -48,6 +48,6 @@ data:
       {{- .configuration.configuration | nindent 6 }}
 
     logger:
-      {{- toYaml .configuration.logger | nindent 4 }}
+      {{- toYaml .configuration.logger | nindent 6 }}
 
 {{- end }}

--- a/charts/free5gc/charts/free5gc-amf/values.yaml
+++ b/charts/free5gc/charts/free5gc-amf/values.yaml
@@ -213,8 +213,8 @@ amf:
         maxAttempts: 2 # the maximum attempts of each sctp connection
         maxInitTimeout: 2 # the maximum init timeout of each sctp connection
       defaultUECtxReq: false # the default value of UE Context Request to decide when triggering Initial Context Setup procedure
-    logger: |-
-      logger: # log output setting
-        enable: true # true or false
-        level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-        reportCaller: false # enable the caller report or not, value: true or false
+
+    logger: # log output setting
+      enable: true # true or false
+      level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+      reportCaller: false # enable the caller report or not, value: true or false

--- a/charts/free5gc/charts/free5gc-ausf/values.yaml
+++ b/charts/free5gc/charts/free5gc-ausf/values.yaml
@@ -104,8 +104,7 @@ ausf:
     # the kind of log output
       # debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic
       # ReportCaller: enable the caller report or not, value: true or false
-    logger: |-
-      logger: # log output setting
-        enable: true # true or false
-        level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-        reportCaller: false # enable the caller report or not, value: true or false
+    logger: # log output setting
+      enable: true # true or false
+      level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+      reportCaller: false # enable the caller report or not, value: true or false

--- a/charts/free5gc/charts/free5gc-n3iwf/values.yaml
+++ b/charts/free5gc/charts/free5gc-n3iwf/values.yaml
@@ -153,11 +153,10 @@ n3iwf:
     # the kind of log output
       # debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic
       # ReportCaller: enable the caller report or not, value: true or false
-    logger: |-
-      logger: # log output setting
-        enable: true # true or false
-        level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-        reportCaller: false # enable the caller report or not, value: true or false
+    logger: # log output setting
+      enable: true # true or false
+      level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+      reportCaller: false # enable the caller report or not, value: true or false
 
 # These parameters apply in case of deployinh N3IWF if a different cluster from the one where AMF is deployed and a Kubernetes service is used for AMF' N2 interface
 multiCluster: false

--- a/charts/free5gc/charts/free5gc-nrf/values.yaml
+++ b/charts/free5gc/charts/free5gc-nrf/values.yaml
@@ -112,8 +112,7 @@ nrf:
       DefaultPlmnId:
         mcc: 208
         mnc: 93
-    logger: |-
-      logger: # log output setting
-        enable: true # true or false
-        level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-        reportCaller: false # enable the caller report or not, value: true or false
+    logger: # log output setting
+      enable: true # true or false
+      level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+      reportCaller: false # enable the caller report or not, value: true or false

--- a/charts/free5gc/charts/free5gc-nssf/values.yaml
+++ b/charts/free5gc/charts/free5gc-nssf/values.yaml
@@ -306,8 +306,7 @@ nssf:
     # the kind of log output
       # debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic
       # ReportCaller: enable the caller report or not, value: true or false
-    logger: |-
-      logger: # log output setting
-        enable: true # true or false
-        level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-        reportCaller: false # enable the caller report or not, value: true or false
+    logger: # log output setting
+      enable: true # true or false
+      level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+      reportCaller: false # enable the caller report or not, value: true or false

--- a/charts/free5gc/charts/free5gc-pcf/values.yaml
+++ b/charts/free5gc/charts/free5gc-pcf/values.yaml
@@ -116,8 +116,7 @@ pcf:
     # the kind of log output
       # debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic
       # ReportCaller: enable the caller report or not, value: true or false
-    logger: |-
-      logger: # log output setting
-        enable: true # true or false
-        level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-        reportCaller: false # enable the caller report or not, value: true or false
+    logger: # log output setting
+      enable: true # true or false
+      level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+      reportCaller: false # enable the caller report or not, value: true or false

--- a/charts/free5gc/charts/free5gc-smf/values.yaml
+++ b/charts/free5gc/charts/free5gc-smf/values.yaml
@@ -167,12 +167,12 @@ smf:
                           - cidr: 10.1.128.0/17
                         staticPools:
                           - cidr: 10.1.192.0/24
-              interfaces: # Interface list for this UPF
-                - interfaceType: N3 # the type of the interface (N3 or N9)
-                  endpoints: # the IP address of this N3/N9 interface on this UPF
-                    - 10.100.50.233
-                  networkInstances: 
-                    - internet # Data Network Name (DNN)
+            interfaces: # Interface list for this UPF
+                  - interfaceType: N3 # the type of the interface (N3 or N9)
+                    endpoints: # the IP address of this N3/N9 interface on this UPF
+                      - 10.100.50.233
+                    networkInstances:
+                      - internet # Data Network Name (DNN)
         links: # the topology graph of userplane, A and B represent the two nodes of each link
           - A: gNB1
             B: UPF

--- a/charts/free5gc/charts/free5gc-smf/values.yaml
+++ b/charts/free5gc/charts/free5gc-smf/values.yaml
@@ -177,7 +177,6 @@ smf:
           - A: gNB1
             B: UPF
       locality: area1 # Name of the location where a set of AMF, SMF and UPFs are located
-
       t3591:
         enable: true     # true or false
         expireTime: 16s   # default is 6 seconds
@@ -204,7 +203,6 @@ smf:
             # the order of UPF nodes in this path. We use the UPF's name to represent each UPF node.
             # The UPF's name should be consistent with smfcfg.yaml
             path: [BranchingUPF, AnchorUPF2]
-
       UE2: # Group Name
         members:
         - imsi-208930000000004 # Subscription Permanent Identifier of the UE

--- a/charts/free5gc/charts/free5gc-smf/values.yaml
+++ b/charts/free5gc/charts/free5gc-smf/values.yaml
@@ -176,6 +176,7 @@ smf:
           - A: gNB1
             B: UPF
       locality: area1 # Name of the location where a set of AMF, SMF and UPFs are located
+
       t3591:
         enable: true     # true or false
         expireTime: 16s   # default is 6 seconds
@@ -202,6 +203,7 @@ smf:
             # the order of UPF nodes in this path. We use the UPF's name to represent each UPF node.
             # The UPF's name should be consistent with smfcfg.yaml
             path: [BranchingUPF, AnchorUPF2]
+
       UE2: # Group Name
         members:
         - imsi-208930000000004 # Subscription Permanent Identifier of the UE

--- a/charts/free5gc/charts/free5gc-smf/values.yaml
+++ b/charts/free5gc/charts/free5gc-smf/values.yaml
@@ -171,8 +171,7 @@ smf:
                   - interfaceType: N3 # the type of the interface (N3 or N9)
                     endpoints: # the IP address of this N3/N9 interface on this UPF
                       - 10.100.50.233
-                    networkInstance:
-                      - internet # Data Network Name (DNN)
+                    networkInstance: internet # Data Network Name (DNN)
         links: # the topology graph of userplane, A and B represent the two nodes of each link
           - A: gNB1
             B: UPF

--- a/charts/free5gc/charts/free5gc-smf/values.yaml
+++ b/charts/free5gc/charts/free5gc-smf/values.yaml
@@ -167,11 +167,12 @@ smf:
                           - cidr: 10.1.128.0/17
                         staticPools:
                           - cidr: 10.1.192.0/24
-            interfaces: # Interface list for this UPF
-                  - interfaceType: N3 # the type of the interface (N3 or N9)
-                    endpoints: # the IP address of this N3/N9 interface on this UPF
-                      - 10.100.50.233
-                    networkInstance: internet # Data Network Name (DNN)
+              interfaces: # Interface list for this UPF
+                - interfaceType: N3 # the type of the interface (N3 or N9)
+                  endpoints: # the IP address of this N3/N9 interface on this UPF
+                    - 10.100.50.233
+                  networkInstances: 
+                    - internet # Data Network Name (DNN)
         links: # the topology graph of userplane, A and B represent the two nodes of each link
           - A: gNB1
             B: UPF

--- a/charts/free5gc/charts/free5gc-smf/values.yaml
+++ b/charts/free5gc/charts/free5gc-smf/values.yaml
@@ -221,8 +221,7 @@ smf:
             # The UPF's name should be consistent with smfcfg.yaml
             path: [BranchingUPF, AnchorUPF2]
 
-    logger: |-
-      logger: # log output setting
-        enable: true # true or false
-        level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-        reportCaller: false # enable the caller report or not, value: true or false
+    logger: # log output setting
+      enable: true # true or false
+      level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+      reportCaller: false # enable the caller report or not, value: true or false

--- a/charts/free5gc/charts/free5gc-udm/values.yaml
+++ b/charts/free5gc/charts/free5gc-udm/values.yaml
@@ -107,8 +107,7 @@ udm:
           PrivateKey: F1AB1074477EBCC7F554EA1C5FC368B1616730155E0041AC447D6301975FECDA
           PublicKey: 0472DA71976234CE833A6907425867B82E074D44EF907DFB4B3E21C1C2256EBCD15A7DED52FCBB097A4ED250E036C7B9C8C7004C4EEDC4F068CD7BF8D3F900E3B4
 
-    logger: |-
-      logger: # log output setting
-        enable: true # true or false
-        level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-        reportCaller: false # enable the caller report or not, value: true or false
+    logger: # log output setting
+      enable: true # true or false
+      level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+      reportCaller: false # enable the caller report or not, value: true or false

--- a/charts/free5gc/charts/free5gc-udr/values.yaml
+++ b/charts/free5gc/charts/free5gc-udr/values.yaml
@@ -110,19 +110,10 @@ udr:
     # the kind of log output
       # debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic
       # ReportCaller: enable the caller report or not, value: true or false
-    logger:
-      UDR:
-        debugLevel: info
-        ReportCaller: false
-      MongoDBLibrary:
-        debugLevel: info
-        ReportCaller: false
-      PathUtil:
-        debugLevel: info
-        ReportCaller: false
-      OpenApi:
-        debugLevel: info
-        ReportCaller: false
+    logger: # log output setting
+      enable: true # true or false
+      level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+      reportCaller: false # enable the caller report or not, value: true or false
 
 free5gc:
   configmap:

--- a/charts/free5gc/charts/free5gc-udr/values.yaml
+++ b/charts/free5gc/charts/free5gc-udr/values.yaml
@@ -137,8 +137,7 @@ free5gc:
     #info
     #debug
     #trace
-    logger: |-
-      logger: # log output setting
-        enable: true # true or false
-        level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-        reportCaller: false # enable the caller report or not, value: true or false
+    logger: # log output setting
+      enable: true # true or false
+      level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+      reportCaller: false # enable the caller report or not, value: true or false

--- a/charts/free5gc/charts/free5gc-webui/values.yaml
+++ b/charts/free5gc/charts/free5gc-webui/values.yaml
@@ -109,8 +109,7 @@ webui:
     # the kind of log output
     # debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic
     # ReportCaller: enable the caller report or not, value: true or false
-    logger: |-
-      logger: # log output setting
-        enable: true # true or false
-        level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-        reportCaller: false # enable the caller report or not, value: true or false
+    logger: # log output setting
+      enable: true # true or false
+      level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+      reportCaller: false # enable the caller report or not, value: true or false


### PR DESCRIPTION
Hi, I was facing some failure deploying. In particular after the upgrade to [Free5gc 3.3.0 PR](https://github.com/Orange-OpenSource/towards5gs-helm/pull/86)
The first pods to fail were web-ui and then nrf

```
kubectl logs -n free5gc v1-free5gc-webui-webui-5f98d9894c-q5fbn
Defaulted container "webui" out of: webui, wait-mongo (init)
2023-06-22T10:00:33.243794298Z [INFO][WEBUI][Main] WEBUI version:
        free5GC version: v3.3.0
        build time:      2023-06-20T08:01:33Z
        commit hash:     2b9cc4c3
        commit time:     2023-05-31T04:51:46Z
        go version:      go1.17.8 linux/amd64
2023-06-22T10:00:33.243960621Z [INFO][WEBUI][CFG] Read config from [../config/webuicfg.yaml]
2023-06-22T10:00:33.244171346Z [ERRO][WEBUI][Main] WEBUI Run error: ReadConfig [../config/webuicfg.yaml] Error: [Factory] yaml: unmarshal errors:
  line 11: cannot unmarshal !!str `logger:...` into factory.Logger
```


In this review I indented correctly and fixed a typo in the SMF value. Based on the [Free5gc config](https://github.com/free5gc/free5gc/tree/main/config)

Output:

```
$ kubectl get po -n free5gc
NAME                                            READY   STATUS    RESTARTS   AGE
mongodb-0                                       1/1     Running   0          5m57s
v1-free5gc-amf-amf-7d847dd9f6-85qbj             1/1     Running   0          5m57s
v1-free5gc-ausf-ausf-779748fcf9-ft4p8           1/1     Running   0          5m57s
v1-free5gc-dbpython-dbpython-685b45dfcb-d8wxd   1/1     Running   0          5m55s
v1-free5gc-nrf-nrf-6dc8f75588-6f5ht             1/1     Running   0          5m57s
v1-free5gc-nssf-nssf-79fc47bc87-pgzhp           1/1     Running   0          5m57s
v1-free5gc-pcf-pcf-79dc77454f-x2jmc             1/1     Running   0          5m56s
v1-free5gc-smf-smf-685d574d8f-x4tfr             1/1     Running   0          5m56s
v1-free5gc-udm-udm-5d99f9976b-cw59z             1/1     Running   0          5m56s
v1-free5gc-udr-udr-557648884b-xrjh2             1/1     Running   0          5m57s
v1-free5gc-upf-upf-cfbbbc6d-dtkxc               1/1     Running   0          5m56s
v1-free5gc-webui-webui-869889b8b5-wjkhr         1/1     Running   0          5m56s
```