### PR TITLE
update open5gs configuration

### DIFF
--- a/charts/ueransim/open5gs-values.yaml
+++ b/charts/ueransim/open5gs-values.yaml
@@ -10,6 +10,25 @@
 # Author: Abderaouf KHICHANE, Ilhem FAJJARI, Ayoub BOUSSELMI
 # Software description: An open-source project providing Helm charts to deploy 5G components (Core + RAN) on top of Kubernetes
 #
+global:
+  #Global network parametes
+  n2network:
+    name: n2network
+    type: macvlan
+    masterIf: eth0
+    subnetIP: 10.100.50.248
+    cidr: 29
+    gatewayIP: 10.100.50.254
+    excludeIP: 10.100.50.254
+  n3network:
+    name: n3network
+    type: macvlan
+    masterIf: eth0
+    subnetIP: 10.100.50.232
+    cidr: 29
+    gatewayIP: 10.100.50.238
+    excludeIP: 10.100.50.238
+
 gnb:
   configuration: |-
     nci: '0x000000010'  # NR Cell Identity (36-bit)


### PR DESCRIPTION
This pull request addresses the issue where the configuration for ueransim was missing to work with Open5GS. The absence of this configuration was causing issues in the GNodeB(gnb) of ueransim.

Changes Made:
Added the necessary configurations in `charts/ueransim/open5gs-values.yaml`.
Tested the changes in a local environment to verify their correctness.